### PR TITLE
Ft directory settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ If you need to you can specify those directories in the -f argument to get the t
 If there is a need please put in a feature request on GitHub.
 
 ### OPTIONS
-
+```
 Usage:
   flowcat [-h] (-f folder) [-o outfile] [-l] [-m match]
 
@@ -82,3 +82,4 @@ Options for Flowcat:
     Optional output file to dump results to, note output will still be shown on terminal.
 -h
     This help menu
+```

--- a/main.go
+++ b/main.go
@@ -143,16 +143,23 @@ func main() {
 	}
 	err = yaml.Unmarshal(settings, &cfg)
 	err = yaml.Unmarshal(settings, &cfg.IgnoredItems)
-	fmt.Println(&cfg)
 	//@todo check what happens if settings file is missing a setting
-	showlines, _ = strconv.ParseBool(cfg.Linenums)
-	fmt.Println(showlines) //@todo why is this returning false always
+	showlines, err = strconv.ParseBool(cfg.Linenums)
+	//@todo should this block? else what should the default be
+	if err != nil {
+		fmt.Println("linenum should be true or false")
+	}
 	if *lineFlag != false {
 		showlines = *lineFlag
 	}
 	matchexp = cfg.Match
+	fmt.Println(matchexp)
 	if *matchFlag != "" {
 		matchexp = *matchFlag
+	}
+	//Fallback incase settings is missing the match and one is not specified per an argument
+	if matchexp == "" {
+		matchexp = "//@todo"
 	}
 
 	parseFiles := func(path string, info os.FileInfo, _ error) (err error) {

--- a/main.go
+++ b/main.go
@@ -13,6 +13,8 @@ import (
 
 //@todo add more architectures under bin folder
 //@todo update master branch build badge
+//@todo add section in readme about building from source
+//@todo add section in readme about regex for -m option
 var ListedFiles []string
 
 func testExclude(path string, outfile string) (string, bool) {

--- a/main.go
+++ b/main.go
@@ -10,15 +10,16 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v2"
 )
 
 type Config struct {
-	Linenums     bool
-	Match        string
-	IgnoredItems map[string][]string
+	Linenums     string              `yaml:"linenum"`
+	Match        string              `yaml:"match"`
+	IgnoredItems map[string][]string `yaml:"ignore"`
 }
 
 type Ignored struct {
@@ -133,7 +134,6 @@ func main() {
 		}
 		//always exit without running if we were using init argument
 		os.Exit(0)
-
 	}
 
 	//Get settings if there is a settings file in the current directory
@@ -143,8 +143,9 @@ func main() {
 	}
 	err = yaml.Unmarshal(settings, &cfg)
 	err = yaml.Unmarshal(settings, &cfg.IgnoredItems)
+	fmt.Println(&cfg)
 	//@todo check what happens if settings file is missing a setting
-	showlines = cfg.Linenums
+	showlines, _ = strconv.ParseBool(cfg.Linenums)
 	fmt.Println(showlines) //@todo why is this returning false always
 	if *lineFlag != false {
 		showlines = *lineFlag


### PR DESCRIPTION
Adds flowcat init 
This argument adds the ability to have a settings file in each project folder so users do not need to pass arguments each time flowcat is run.